### PR TITLE
Add tflite models to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ flash_builder/flash_builder/__pycache__/
 flash_builder/.eggs/
 flash_builder/flash_builder.egg-info/
 *.pyc
+*.tflite
 


### PR DESCRIPTION
As suggested, they can still be added but they will not be included by accident.