### PR TITLE
fix unterminated ifdef, host compilation on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
         "-O0"
     )
 
-    list(APPEND DEFINTIONS "NN_USE_REF")
+    list(APPEND DEFINTIONS "NN_USE_REF" "FLATBUFFERS_LOCALE_INDEPENDENT=0")
 
     target_compile_features(xtflitemicro PUBLIC cxx_std_17)
 endif()

--- a/tflite_micro_compiler/src/Compiler.cc
+++ b/tflite_micro_compiler/src/Compiler.cc
@@ -1212,17 +1212,17 @@ TfLiteStatus )"
   mg_InvokeSubgraph(0);
 
   thread_destroy(&xc_config.thread_info);
-
-#ifdef TFLMC_CONV2D_PROFILE
+)";
+  if (has_xc_conv_ops) {
+    wr << R"(
+  #ifdef TFLMC_CONV2D_PROFILE
   struct convopdata{
     const char * name;
     size_t thread_count;
     int evalStartTime;
     int threadsStartTime;
     int threadsDoneTime;
-  };)";
-  if (has_xc_conv_ops) {
-    wr << R"(
+  };
   int conv_times1 = 0, conv_times2 = 0;
   printf("\n\nConv()...");
   for(size_t g = 0; g < )"


### PR DESCRIPTION
- Fix bug with models not compiling without conv layers due to unterminated ifdef (introduced in #133)
- Add flag for host compilation on Linux