### PR TITLE
setting fixed nproc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ patch:
 
 build:
 	(cd lib_tflite_micro && ../version_check.sh)
-	(cmake -B build && make -j$(nproc) -C build)
+	(cmake -B build && make -j8 -C build)
 
 init:
 	python3 fetch_dependencies.py


### PR DESCRIPTION
for some reason ``-j$(nproc)`` makes jenkins unhappy, so reverting to -j8