### PR TITLE
fixing stack warning usage by inlining paging and anotating usage

### DIFF
--- a/tflite_micro_compiler/src/Compiler.cc
+++ b/tflite_micro_compiler/src/Compiler.cc
@@ -1212,7 +1212,7 @@ wr << R"(
 }
 
 wr << R"(
-#pragma stackfunction 1000
+static __attribute__((always_inline))
 TfLiteStatus )"
      << prefix_ << R"(init_with_paging(void *weights_data_ptr, void *paging_ptr) {)";
   if (has_xc_async_ops) {
@@ -1419,6 +1419,8 @@ TfLiteStatus )"
   asm(".resource_const " # FN ", \"stack_frame_bytes\", " # BYTES);
 
 STACKFUNCTION_STATIC(_ZN12_GLOBAL__N_117mg_InvokeSubgraphEi, 1000);
+STACKFUNCTION_STATIC(_Z)" << (prefix_.size() + 4) << prefix_ << R"(initPv, 1024);
+
 #endif
 
 static TfLiteStatus mg_status;


### PR DESCRIPTION
this fixes the following:

```console
ld.lld: warning: input resource value not defined: callees
>>> in expression: MAX stack_bytes, stack_bytes, callees
>>> when calculating resource value for symbol: _Z32model_xxx_init_with_pagingPvS_       
```