### PR TITLE
Add Cmake option for func/data sections and gc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL XCORE_XS)
 
     list(APPEND DEFINITIONS "FLATBUFFERS_LOCALE_INDEPENDENT=0")
 
-else() # host app
+else()
     set(BUILD_FLAGS
         "-g"
         "-O0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.23)
 
+option(
+    ENABLE_SIZE_OPT
+    "Enable function/data section splitting and linker garbage collection"
+    OFF
+)
+
 # **********************
 # Disable in-source build.
 # **********************
@@ -43,7 +49,6 @@ set(DEFINITIONS
 )
 
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL XCORE_XS3A)
-    # # Set the target
     set(XCORE_TARGET "XCORE-AI-EXPLORER")
 
     enable_language(CXX C ASM)
@@ -86,9 +91,9 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL XCORE_XS)
     SET(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
     set_property(TARGET ${LIB_NAME} PROPERTY CXX_STANDARD 14)
 
-
     list(APPEND DEFINITIONS "FLATBUFFERS_LOCALE_INDEPENDENT=0")
-else()
+
+else() # host app
     set(BUILD_FLAGS
         "-g"
         "-O0"
@@ -98,6 +103,10 @@ else()
     list(APPEND DEFINITIONS "NN_USE_REF" "FLATBUFFERS_LOCALE_INDEPENDENT=0")
 
     target_compile_features(${LIB_NAME} PUBLIC cxx_std_17)
+endif()
+
+if(ENABLE_SIZE_OPT)
+    list(APPEND BUILD_FLAGS -ffunction-sections -fdata-sections -Wl,--gc-sections)
 endif()
 
 target_compile_options(${LIB_NAME} PRIVATE ${BUILD_FLAGS})


### PR DESCRIPTION
Adds ENABLE_SIZE_OPT Cmake option.

If enabled, appends to the Build options the following flags:
-ffunction-sections 
-fdata-sections 
-Wl,--gc-sections